### PR TITLE
Feature/update project structure

### DIFF
--- a/src/blocks/section/edit.js
+++ b/src/blocks/section/edit.js
@@ -1,7 +1,9 @@
 import { InnerBlocks } from "@wordpress/block-editor";
-import { Component, useState, useEffect } from "@wordpress/element";
+import { Component } from "@wordpress/element";
 import { SelectControl, Button, TextControl } from "@wordpress/components";
 import { withSelect } from "@wordpress/data";
+
+const { useEffect, useState } = wp.element;
 
 const ColumnsSettings = props => {
   const { onChangeValue, settings } = props;
@@ -71,7 +73,7 @@ const RowSectionEdit = ({ currentBlock, attributes, setAttributes, clientId, ...
     let newColumnsStyle = '';
     currentBlock.innerBlocks.map((innerBlock, index) => {
       const numberOfColumns = innerBlock.attributes.columns;
-      newColumnsStyle += `.kili-columns > .kili-section__row-${clientId} > .editor-inner-blocks > .editor-block-list__layout > [data-type="kili-blocks/k-column"]:nth-child(${index + 1}) {
+      newColumnsStyle += `.kili-columns > .kili-section__row-${clientId} > .editor-inner-blocks > .editor-block-list__layout > [data-type="kili/k-column"]:nth-child(${index + 1}) {
         flex-basis: ${(numberOfColumns / 12)*100}%;
         margin-left: 0;
         margin-right: 0;

--- a/src/blocks/section/parent.js
+++ b/src/blocks/section/parent.js
@@ -28,11 +28,11 @@ registerBlockType("kili/k-section", {
   title: __("Kili-Row", "kili-builder"),
   description: __(
     "Add section where you can create diferents sections for the main page",
-    "kili-blocks"
+    "kili-builder"
   ),
   category: "kili-builder",
   icon: "text",
-  keywords: [__("Section", "kili-blocks")],
+  keywords: [__("Section", "kili-builder")],
   supports: {
     html: false,
     align: true,
@@ -71,7 +71,7 @@ registerBlockType("kili/k-section", {
     return (
       <>
         <InspectorControls>
-          <PanelBody title={__("Row Settings", "kili-blocks")}>
+          <PanelBody title={__("Row Settings", "kili-builder")}>
             <ToggleControl
               label="Background Full-Width"
               onChange={value =>
@@ -82,7 +82,7 @@ registerBlockType("kili/k-section", {
               checked={fullWidth}
             />
           </PanelBody>
-          <PanelBody title={__("Background Settings", "kili-blocks")}>
+          <PanelBody title={__("Background Settings", "kili-builder")}>
             <PanelRow>
               <MediaUploadCheck>
                 <MediaUpload
@@ -106,7 +106,7 @@ registerBlockType("kili/k-section", {
               </MediaUploadCheck>
               {id && (
                 <>
-                  <Tooltip text={__("Remove Image", "kili-core")}>
+                  <Tooltip text={__("Remove Image", "kili-builder")}>
                     <Button
                       className={"button--close"}
                       onClick={() => onRemoveImage()}
@@ -120,7 +120,7 @@ registerBlockType("kili/k-section", {
             <PanelRow>{url && <img src={url} alt={alt} />}</PanelRow>
           </PanelBody>
         </InspectorControls>
-        <InnerBlocks template={[["kili-blocks/row-section"]]} />
+        <InnerBlocks template={[["kili/row-section"]]} />
       </>
     );
   },

--- a/src/init.php
+++ b/src/init.php
@@ -53,7 +53,7 @@ function kili_blocks_register_block_type( $block, $options=array() ){
     array_merge(
       array(
         'editor_script' => 'kili-editor-script',
-        'editor_style' => 'kili-editor-style',
+        'style' => 'kili-style',
       ),
       $options
     )
@@ -64,7 +64,7 @@ function kili_blocks_register_block_type( $block, $options=array() ){
 function kili_blocks_register() {
 	wp_register_script( 'kili-editor-script',
 		plugins_url( 'dist/blocks.js', dirname(__FILE__) ),
-		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-editor', 'wp-blob', 'wp-data')
+		array( 'wp-blocks', 'wp-i18n', 'wp-block-editor', 'wp-components', 'wp-editor', 'wp-blob', 'wp-data')
 	);
 
   	wp_register_style( 'kili-style',

--- a/src/init.php
+++ b/src/init.php
@@ -68,7 +68,7 @@ function kili_blocks_register() {
 	);
 
   	wp_register_style( 'kili-style',
-  		plugins_url( 'dist/style.css', dirname( __FILE__ ) )
+  		plugins_url( 'dist/main.css', dirname( __FILE__ ) )
 	);
 
 	$scripts_array = get_scripts_array();


### PR DESCRIPTION
Changed the @wordpress/element importing to wp.element. This way we can use React Hooks without version problems between the multiple instances of React available in the wordpress core modules.