### PR TITLE
Update style parser and fix font styles component controlls

### DIFF
--- a/src/blocks/banner/edit.js
+++ b/src/blocks/banner/edit.js
@@ -66,9 +66,9 @@ function BannerEdit( props ) {
                   style={
                     editClassCreator( attributes ),
                     {
-                      fontSize: `${ fontSizeValue }px`,
-                      letterSpacing: `${ letterSpacingValue }px`,
-                      lineHeight: `${ lineHeightValue }px`,
+                      fontSize: `${ fontSizeValue }`,
+                      letterSpacing: `${ letterSpacingValue }`,
+                      lineHeight: `${ lineHeightValue }`,
                     }
                   }
                   as="h2"

--- a/src/blocks/column/edit.js
+++ b/src/blocks/column/edit.js
@@ -14,7 +14,8 @@ const { useState, useEffect, useCallback } = wp.element;
 
 function ColumnEdit( props ) {
   const { setAttributes, attributes, clientId, className, hasInnerBlocks,
-    parentId } = props;
+    parentId, isSelected } = props;
+
   const [ selectedWidth, setSelectedWidth ] = useState( 0 );
   const [ parentWidth, setParentWidth ] = useState( 0 );
   const [ , setResizing ] = useState( false );
@@ -48,7 +49,7 @@ function ColumnEdit( props ) {
       minHeight="20"
       enable={ {
         top: false,
-        right: true,
+        right: isSelected,
         bottom: false,
         left: false,
         topRight: false,

--- a/src/blocks/column/save.js
+++ b/src/blocks/column/save.js
@@ -12,9 +12,9 @@ export default function ColumnSave( { attributes } ) {
       let cssProperty = '';
       const value = ( columns[ device ].value / 12 ) * 100;
       if ( value ) {
-        cssProperty = ` ${ columns[ device ].prefix }--flex-basis__${ Number( value.toFixed( 3 ) ) }`;
+        cssProperty = ` ${ columns[ device ].prefix }--flex-basis__${ Number( value.toFixed( 3 ) ) }%`;
         gridClasses += cssProperty;
-        cssProperty = ` ${ columns[ device ].prefix }--max-width__${ Number( value.toFixed( 3 ) ) }`;
+        cssProperty = ` ${ columns[ device ].prefix }--max-width__${ Number( value.toFixed( 3 ) ) }%`;
         gridClasses += cssProperty;
       }
     }

--- a/src/blocks/container/attributes.js
+++ b/src/blocks/container/attributes.js
@@ -2,8 +2,8 @@ import backgroundAttributes from '../../components/Background/attributes';
 import { defaultAttrBuiler } from '../utils';
 
 export default {
-  maxWidth: defaultAttrBuiler('max-width', 1200),
-  minHeight: defaultAttrBuiler('minHeight'),
+  maxWidth: defaultAttrBuiler( 'max-width', 1200 ),
+  minHeight: defaultAttrBuiler( 'minHeight' ),
   fullWidth: {
     type: 'boolean',
     default: false,
@@ -20,5 +20,5 @@ export default {
     type: 'string',
     default: '',
   },
-  ...backgroundAttributes
+  ...backgroundAttributes,
 };

--- a/src/blocks/container/edit.js
+++ b/src/blocks/container/edit.js
@@ -3,7 +3,7 @@ import Inspector from './inspector';
 import { editClassCreator } from '../utils/editClassCreator';
 
 export default function ContainerEdit( props ) {
-  const { attributes } = props;
+  const { attributes, isSelected } = props;
   const { minHeight, maxWidth, ...rest } = attributes;
 
   return (
@@ -11,7 +11,7 @@ export default function ContainerEdit( props ) {
       <Inspector { ...props } />
       <div style={ editClassCreator( { minHeight, maxWidth } ) } className="kili-container" >
         <div style={ editClassCreator( rest ) } className="kili-container__overlay" />
-        <InnerBlocks renderAppender={ InnerBlocks.ButtonBlockAppender } />
+        <InnerBlocks renderAppender={ isSelected && InnerBlocks.ButtonBlockAppender } />
       </div>
     </>
   );

--- a/src/blocks/container/save.js
+++ b/src/blocks/container/save.js
@@ -1,8 +1,12 @@
+import { InnerBlocks } from '@wordpress/block-editor';
+import { attrClassCreator } from '../utils';
 
-export default function ContainerSave() {
+export default function ContainerSave( { attributes } ) {
+  const classes = attrClassCreator( attributes );
+
   return (
-    <div>
-
+    <div className={ `${ classes }` }>
+      <InnerBlocks.Content />
     </div>
   );
 }

--- a/src/blocks/heading/edit.js
+++ b/src/blocks/heading/edit.js
@@ -6,11 +6,14 @@ import { getDeviceValue } from '../utils';
 
 const MaComp = ( props ) => {
   const { attributes, setAttributes } = props;
-  const { currentTab, color, level, fontSize, textAlign, lineHeight, letterSpacing, includeLines, linesColor, linesSize } = attributes;
+  const { currentTab, color, level, fontSize, textAlign, lineHeight, letterSpacing, includeLines, linesColor, linesSize, fontWeight } = attributes;
 
   const onTextChange = ( text ) => setAttributes( { text } );
   const tagName = 'h' + level;
   const fontSizeValue = getDeviceValue( fontSize, currentTab );
+  const fontWeightValue = getDeviceValue( fontWeight, currentTab );
+  console.log( fontWeight );
+
   const colorValue = getDeviceValue( color, currentTab );
   const linesColorValue = getDeviceValue( linesColor, currentTab );
   const linesSizeValue = getDeviceValue( linesSize, currentTab );
@@ -49,16 +52,17 @@ const MaComp = ( props ) => {
       <Inspector { ...props } />
       <RichText
         style={ {
-          fontSize: `${ fontSizeValue }px`,
+          fontSize: `${ fontSizeValue }`,
+          fontWeight: fontWeightValue,
           fontFamily: 'Gt Walsheim',
           color: colorValue,
-          letterSpacing: `${ letterSpacingValue }px`,
-          lineHeight: `${ lineHeightValue }px`,
+          letterSpacing: `${ letterSpacingValue }`,
+          lineHeight: `${ lineHeightValue }`,
           textAlign: textAlignValue,
           opacity: .8,
         } }
         className="kili-heading"
-        tagName={ tagName }
+        tagName={ level && tagName }
         onChange={ onTextChange }
         value={ attributes.text }
       />

--- a/src/blocks/heading/edit.js
+++ b/src/blocks/heading/edit.js
@@ -12,8 +12,6 @@ const MaComp = ( props ) => {
   const tagName = 'h' + level;
   const fontSizeValue = getDeviceValue( fontSize, currentTab );
   const fontWeightValue = getDeviceValue( fontWeight, currentTab );
-  console.log( fontWeight );
-
   const colorValue = getDeviceValue( color, currentTab );
   const linesColorValue = getDeviceValue( linesColor, currentTab );
   const linesSizeValue = getDeviceValue( linesSize, currentTab );

--- a/src/blocks/heading/inspector.js
+++ b/src/blocks/heading/inspector.js
@@ -12,8 +12,8 @@ export default function Inspector( props ) {
 
   const handleAttributeChange = ( attribute, value ) => setAttributes( { [ attribute ]: value } );
 
-  const linesColorValue = getDeviceValue(linesColor, currentTab);  
-  const linesSizeValue = getDeviceValue(linesSize, currentTab);  
+  const linesColorValue = getDeviceValue( linesColor, currentTab );
+  const linesSizeValue = getDeviceValue( linesSize, currentTab );
 
   return (
     <InspectorControls>
@@ -33,7 +33,7 @@ export default function Inspector( props ) {
                   checked={ includeLines }
                   onChange={ ( value ) => handleAttributeChange( 'includeLines', value ) }
                 />
-                {includeLines && (
+                { includeLines && (
                   <>
                     <AdvancedColorControl
                       label={ __( 'Lines Color', 'kili-builder' ) }
@@ -41,7 +41,7 @@ export default function Inspector( props ) {
                       colorDefault={ linesColorValue }
                       onColorChange={ ( value ) => setAttributes( { linesColor: valueSetter( linesColor, currentTab, value ) } ) }
                     />
-                     <RangeControl
+                    <RangeControl
                       label={ __( 'Lines Size', 'kili-builder' ) }
                       value={ linesSizeValue }
                       onChange={ ( value ) => setAttributes( { linesSize: valueSetter( linesSize, currentTab, value ) } ) }
@@ -50,11 +50,11 @@ export default function Inspector( props ) {
                       step={ 1 }
                     />
                   </>
-                )}
+                ) }
               </PanelBody>
-              <FontStyles {...props} isHeading />
-              
-            </> 
+              <FontStyles { ...props } isHeading />
+
+            </>
           );
         } }
       </TabPanel>

--- a/src/blocks/heading/save.js
+++ b/src/blocks/heading/save.js
@@ -6,7 +6,7 @@ export default function SectionSave( { attributes } ) {
 
   return (
     <div className={ `${ classes }` }>
-      <RichText.Content />
+      <RichText.Content value={ attributes.text } />
     </div>
   );
 }

--- a/src/blocks/paragraph/edit.js
+++ b/src/blocks/paragraph/edit.js
@@ -4,10 +4,11 @@ import { getDeviceValue } from '../utils';
 
 const MaComp = ( props ) => {
   const { attributes, setAttributes } = props;
-  const { currentTab, color, fontSize, textAlign, lineHeight, letterSpacing } = attributes;
+  const { currentTab, color, fontSize, textAlign, lineHeight, letterSpacing, fontWeight } = attributes;
 
   const onTextChange = ( text ) => setAttributes( { text } );
   const fontSizeValue = getDeviceValue( fontSize, currentTab );
+  const fontWeightValue = getDeviceValue( fontWeight, currentTab );
   const colorValue = getDeviceValue( color, currentTab );
   const textAlignValue = getDeviceValue( textAlign, currentTab );
   const lineHeightValue = getDeviceValue( lineHeight, currentTab );
@@ -18,11 +19,12 @@ const MaComp = ( props ) => {
       <Inspector { ...props } />
       <RichText
         style={ {
-          fontSize: `${ fontSizeValue }px`,
+          fontSize: `${ fontSizeValue }`,
+          fontWeightValue: `${ fontWeightValue }`,
           fontFamily: 'Gt Walsheim',
           color: colorValue,
-          letterSpacing: `${ letterSpacingValue }px`,
-          lineHeight: `${ lineHeightValue }px`,
+          letterSpacing: `${ letterSpacingValue }`,
+          lineHeight: `${ lineHeightValue }`,
           textAlign: textAlignValue,
           opacity: .8,
         } }

--- a/src/blocks/paragraph/save.js
+++ b/src/blocks/paragraph/save.js
@@ -4,9 +4,5 @@ import { attrClassCreator } from '../utils';
 export default function SectionSave( { attributes } ) {
   const classes = attrClassCreator( attributes );
 
-  return (
-    <div className={ `${ classes }` }>
-      <RichText.Content />
-    </div>
-  );
+  return <RichText.Content className={ `${ classes }` } tagName="p" value={ attributes.text } />;
 }

--- a/src/blocks/utils/valueSetter.js
+++ b/src/blocks/utils/valueSetter.js
@@ -1,7 +1,7 @@
-export const valueSetter = (obj, device, value) => ({
+export const valueSetter = ( obj, device, value, dimension ) => ( {
   ...obj,
-  [device]: {
-    ...obj[device],
-    value,
-  }
-})
+  [ device ]: {
+    ...obj[ device ],
+    value: `${ value }${ dimension || '' }`,
+  },
+} );

--- a/src/components/FontStyles/attributes.js
+++ b/src/components/FontStyles/attributes.js
@@ -8,11 +8,11 @@ const FontStylesAttributes = {
   },
   level: {
     type: 'number',
-    default: 2,
   },
   textAlign: defaultAttrBuiler( 'text-align', 'center' ),
   color: defaultAttrBuiler( 'color', 'black' ),
-  fontSize: defaultAttrBuiler( 'font-size', 24 ),
+  fontSize: defaultAttrBuiler( 'font-size', '24px' ),
+  fontWeight: defaultAttrBuiler( 'font-weight', 400 ),
   lineHeight: defaultAttrBuiler( 'line-height', 'center' ),
   letterSpacing: defaultAttrBuiler( 'letter-spacing', 'normal' ),
   sizeType: {

--- a/src/components/FontStyles/heading-default-values.js
+++ b/src/components/FontStyles/heading-default-values.js
@@ -2,34 +2,34 @@ import { defaultAttrBuiler } from '../../blocks/utils';
 
 export default {
   1: {
-    fontSize: defaultAttrBuiler( 'font-size', 48 ),
-    lineHeight: defaultAttrBuiler( 'line-height', 50 ),
-    letterSpacing: defaultAttrBuiler( 'letter-spacing', -0.8 ),
+    fontSize: defaultAttrBuiler( 'font-size', '48px' ),
+    lineHeight: defaultAttrBuiler( 'line-height', '50px' ),
+    letterSpacing: defaultAttrBuiler( 'letter-spacing', '-0.8px' ),
   },
   2: {
-    fontSize: defaultAttrBuiler( 'font-size', 32 ),
-    lineHeight: defaultAttrBuiler( 'line-height', 34 ),
-    letterSpacing: defaultAttrBuiler( 'letter-spacing', -0.53 ),
+    fontSize: defaultAttrBuiler( 'font-size', '32px' ),
+    lineHeight: defaultAttrBuiler( 'line-height', '34px' ),
+    letterSpacing: defaultAttrBuiler( 'letter-spacing', '-0.53px' ),
   },
   3: {
-    fontSize: defaultAttrBuiler( 'font-size', 24 ),
-    lineHeight: defaultAttrBuiler( 'line-height', 26 ),
-    letterSpacing: defaultAttrBuiler( 'letter-spacing', -0.4 ),
+    fontSize: defaultAttrBuiler( 'font-size', '24px' ),
+    lineHeight: defaultAttrBuiler( 'line-height', '26px' ),
+    letterSpacing: defaultAttrBuiler( 'letter-spacing', '-0.4px' ),
   },
   4: {
-    fontSize: defaultAttrBuiler( 'font-size', 24 ),
-    lineHeight: defaultAttrBuiler( 'line-height', 26 ),
-    letterSpacing: defaultAttrBuiler( 'letter-spacing', -0.4 ),
+    fontSize: defaultAttrBuiler( 'font-size', '24px' ),
+    lineHeight: defaultAttrBuiler( 'line-height', '26px' ),
+    letterSpacing: defaultAttrBuiler( 'letter-spacing', '-0.4px' ),
   },
   5: {
-    fontSize: defaultAttrBuiler( 'font-size', 24 ),
-    lineHeight: defaultAttrBuiler( 'line-height', 26 ),
-    letterSpacing: defaultAttrBuiler( 'letter-spacing', -0.4 ),
+    fontSize: defaultAttrBuiler( 'font-size', '24px' ),
+    lineHeight: defaultAttrBuiler( 'line-height', '26px' ),
+    letterSpacing: defaultAttrBuiler( 'letter-spacing', '-0.4px' ),
   },
   6: {
-    fontSize: defaultAttrBuiler( 'font-size', 24 ),
-    lineHeight: defaultAttrBuiler( 'line-height', 26 ),
-    letterSpacing: defaultAttrBuiler( 'letter-spacing', -0.4 ),
+    fontSize: defaultAttrBuiler( 'font-size', '24px' ),
+    lineHeight: defaultAttrBuiler( 'line-height', '26px' ),
+    letterSpacing: defaultAttrBuiler( 'letter-spacing', '-0.4px' ),
   },
 };
 

--- a/src/components/FontStyles/index.js
+++ b/src/components/FontStyles/index.js
@@ -14,10 +14,11 @@ const { AlignmentToolbar } = wp.blockEditor;
 
 export default function FontStyles( props ) {
   const { attributes, setAttributes, isHeading } = props;
-  const { currentTab, level, textAlign, color, fontSize, lineHeight, letterSpacing } = attributes;
+  const { currentTab, level, textAlign, color, fontSize, lineHeight, letterSpacing, fontWeight } = attributes;
 
   const alignValue = getDeviceValue( textAlign, currentTab );
   const colorValue = getDeviceValue( color, currentTab );
+  const fontWeightValue = getDeviceValue( fontWeight, currentTab );
   const fontSizeValue = getDeviceValue( fontSize, currentTab );
   const lineHeightValue = getDeviceValue( lineHeight, currentTab );
   const letterSpacingValue = getDeviceValue( letterSpacing, currentTab );
@@ -28,7 +29,6 @@ export default function FontStyles( props ) {
 
   const createLevelControl = ( targetLevel, selectedLevel ) => {
     const isActive = targetLevel === selectedLevel;
-    console.log( getHeadingDefaultValuesFor( targetLevel, 'fontSize' ) );
 
     return {
       icon: (
@@ -79,24 +79,32 @@ export default function FontStyles( props ) {
       />
       <RangeControl
         label={ __( 'Font Size', 'kili-builder' ) }
-        value={ ( fontSizeValue ? fontSizeValue : '' ) }
-        onChange={ ( value ) => setAttributes( { fontSize: valueSetter( fontSize, currentTab, value ) } ) }
+        value={ ( parseFloat( fontSizeValue ) ? parseFloat( fontSizeValue ) : '' ) }
+        onChange={ ( value ) => setAttributes( { fontSize: valueSetter( fontSize, currentTab, value, 'px' ) } ) }
         min={ 5 }
         max={ 200 }
         step={ 1 }
       />
       <RangeControl
+        label={ __( 'Font Weight', 'kili-builder' ) }
+        value={ ( parseFloat( fontWeightValue ) ? parseFloat( fontWeightValue ) : '' ) }
+        onChange={ ( value ) => setAttributes( { fontWeight: valueSetter( fontWeight, currentTab, value ) } ) }
+        min={ 100 }
+        max={ 800 }
+        step={ 100 }
+      />
+      <RangeControl
         label={ __( 'Line Height', 'kili-builder' ) }
-        value={ ( lineHeightValue ? lineHeightValue : '' ) }
-        onChange={ ( value ) => setAttributes( { lineHeight: valueSetter( lineHeight, currentTab, value ) } ) }
+        value={ ( parseFloat( lineHeightValue ) ? parseFloat( lineHeightValue ) : '' ) }
+        onChange={ ( value ) => setAttributes( { lineHeight: valueSetter( lineHeight, currentTab, value, 'px' ) } ) }
         min={ 0 }
         max={ 100 }
         step={ 1 }
       />
       <RangeControl
         label={ __( 'Letter Spacing', 'kili-builder' ) }
-        value={ ( letterSpacingValue ? letterSpacingValue : '' ) }
-        onChange={ ( value ) => setAttributes( { letterSpacing: valueSetter( letterSpacing, currentTab, value ) } ) }
+        value={ ( parseFloat( letterSpacingValue ) ? parseFloat( letterSpacingValue ) : '' ) }
+        onChange={ ( value ) => setAttributes( { letterSpacing: valueSetter( letterSpacing, currentTab, value, 'px' ) } ) }
         min={ -50 }
         max={ 50 }
         step={ 0.1 }


### PR DESCRIPTION
- [x] Changed RegEx to match only classNames from our guidelines ( `${device}--${cssProperty}__${value}` )

- [x] Updated className getter function to be recursive and parse innerBlocks classnames.

- [x] Escaped special characters on classNames ( `. $ #` )

- [x] Added dimension to font attributes, in order to be parsed correctly

- [x] Added font weight attribute to font component

- [x] Display ResizableBox snapper and BlockAppender on selected block only
