### PR TITLE
Added AdvancedControls and cleaned up style attributes picker

### DIFF
--- a/src/blocks/container/attributes.js
+++ b/src/blocks/container/attributes.js
@@ -5,7 +5,7 @@ import { defaultAttrBuiler } from '../utils';
 export default {
   fullWidth: defaultAttrBuiler( null, false ),
   maxWidth: defaultAttrBuiler( 'max-width', '1200px' ),
-  minHeight: defaultAttrBuiler( 'minHeight' ),
+  minHeight: defaultAttrBuiler( 'min-height' ),
   id: {
     type: 'string',
     default: '',

--- a/src/blocks/container/edit.js
+++ b/src/blocks/container/edit.js
@@ -7,6 +7,7 @@ import { editClassCreator } from '../utils/editClassCreator';
 import { DESKTOP } from '../../constants';
 import withStyles from '../../hoc/withStyles';
 import styles from './style';
+import withClientID from '../../hoc/withClientID';
 
 function ContainerEdit( props ) {
   const { attributes } = props;
@@ -24,5 +25,6 @@ function ContainerEdit( props ) {
 }
 
 export default compose(
+  withClientID,
   withStyles( styles ),
 )( ContainerEdit );

--- a/src/blocks/container/inspector.js
+++ b/src/blocks/container/inspector.js
@@ -19,29 +19,48 @@ export default function Inspector( props ) {
     <InspectorControls>
       <DeviceTabProvider>
         { ( { name: tab } ) => (
-          <PanelBody initialOpen title="Dimensions Settings">
-            <AdvancedToggleControl
-              attributeName="fullWidth"
-              label={ __( 'Full Width (pixels)', 'kili-builder' ) }
-            />
-            <AdvancedRangeControl
-              disabled={ fullWidth[ tab ]?.value }
-              label={ __( 'Max Width (pixels)', 'kili-builder' ) }
-              attributeName="maxWidth"
-              dimension="px"
-              min={ 1 }
-              max={ 2000 }
-              step={ 1 }
-            />
-            <AdvancedRangeControl
-              label={ __( 'Min Height (pixels)', 'kili-builder' ) }
-              attributeName="minHeight"
-              dimension="px"
-              min={ 1 }
-              max={ 2000 }
-              step={ 1 }
-            />
-          </PanelBody>
+          <>
+            <PanelBody initialOpen title="Dimensions Settings">
+              <AdvancedToggleControl
+                attributeName="fullWidth"
+                label={ __( 'Full Width', 'kili-builder' ) }
+              />
+              <AdvancedRangeControl
+                disabled={ fullWidth[ tab ]?.value }
+                label={ __( 'Max Width (pixels)', 'kili-builder' ) }
+                attributeName="maxWidth"
+                dimension="px"
+                min={ 1 }
+                max={ 2000 }
+                step={ 1 }
+              />
+              <AdvancedRangeControl
+                label={ __( 'Min Height (pixels)', 'kili-builder' ) }
+                attributeName="minHeight"
+                dimension="px"
+                min={ 1 }
+                max={ 2000 }
+                step={ 1 }
+              />
+            </PanelBody>
+            <PanelBody initialOpen title="Spacing Settings">
+              <DimensionsControl
+                { ...props }
+                device={ tab }
+                type="padding"
+                label={ __( 'Padding', 'kili-builder' ) }
+                help={ __( 'Space inside block', 'kili-builder' ) }
+              />
+              <DimensionsControl
+                { ...props }
+                device={ tab }
+                type="margin"
+                label={ __( 'Margin', 'kili-builder' ) }
+                help={ __( 'Space outside block', 'kili-builder' ) }
+              />
+            </PanelBody>
+            <BackgroundControl { ...props } device={ tab } />
+          </>
         ) }
       </DeviceTabProvider>
     </InspectorControls>

--- a/src/blocks/container/inspector.js
+++ b/src/blocks/container/inspector.js
@@ -13,8 +13,6 @@ const { useCallback } = wp.element;
 export default function Inspector( props ) {
   const { attributes, setAttributes, clientId } = props;
   const { maxWidth, minHeight, fullWidth } = attributes;
-  const { handleAttributesWithDeviceChange } = useAttributeSetter( clientId );
-  console.log( attributes.maxWidth );
 
   return (
     <InspectorControls>
@@ -24,8 +22,7 @@ export default function Inspector( props ) {
             <AdvancedRangeControl
               disabled={ fullWidth[ tab ]?.value }
               label={ __( 'Max Width (pixels)', 'kili-builder' ) }
-              attribute={ maxWidth }
-              onChange={ handleAttributesWithDeviceChange }
+              attributeName={ 'maxWidth' }
               dimension="px"
               min={ 1 }
               max={ 2000 }

--- a/src/blocks/container/inspector.js
+++ b/src/blocks/container/inspector.js
@@ -7,22 +7,35 @@ import DimensionsControl from '../../components/DimensionsControl';
 import useAttributeSetter from '../../hooks/useAttributeSetter';
 import { DeviceTabProvider } from '../../hooks/useDeviceTab';
 import AdvancedRangeControl from '../../components/AdvancedRangeControl';
+import AdvancedToggleControl from '../../components/AdvancedToggleControl/AdvancedToggleControl';
 
 const { useCallback } = wp.element;
 
 export default function Inspector( props ) {
-  const { attributes, setAttributes, clientId } = props;
-  const { maxWidth, minHeight, fullWidth } = attributes;
+  const { attributes } = props;
+  const { fullWidth } = attributes;
 
   return (
     <InspectorControls>
       <DeviceTabProvider>
-        { ( tab ) => (
+        { ( { name: tab } ) => (
           <PanelBody initialOpen title="Dimensions Settings">
+            <AdvancedToggleControl
+              attributeName="fullWidth"
+              label={ __( 'Full Width (pixels)', 'kili-builder' ) }
+            />
             <AdvancedRangeControl
               disabled={ fullWidth[ tab ]?.value }
               label={ __( 'Max Width (pixels)', 'kili-builder' ) }
-              attributeName={ 'maxWidth' }
+              attributeName="maxWidth"
+              dimension="px"
+              min={ 1 }
+              max={ 2000 }
+              step={ 1 }
+            />
+            <AdvancedRangeControl
+              label={ __( 'Min Height (pixels)', 'kili-builder' ) }
+              attributeName="minHeight"
               dimension="px"
               min={ 1 }
               max={ 2000 }
@@ -30,9 +43,7 @@ export default function Inspector( props ) {
             />
           </PanelBody>
         ) }
-
       </DeviceTabProvider>
-
     </InspectorControls>
   );
 }

--- a/src/blocks/container/inspector.js
+++ b/src/blocks/container/inspector.js
@@ -5,6 +5,8 @@ import { __ } from '@wordpress/i18n';
 import BackgroundControl from '../../components/Background';
 import DimensionsControl from '../../components/DimensionsControl';
 import useAttributeSetter from '../../hooks/useAttributeSetter';
+import { DeviceTabProvider } from '../../hooks/useDeviceTab';
+import AdvancedRangeControl from '../../components/AdvancedRangeControl';
 
 const { useCallback } = wp.element;
 
@@ -12,70 +14,28 @@ export default function Inspector( props ) {
   const { attributes, setAttributes, clientId } = props;
   const { maxWidth, minHeight, fullWidth } = attributes;
   const { handleAttributesWithDeviceChange } = useAttributeSetter( clientId );
-
-  const handleWidthChange = useCallback(
-    ( newWidth, type, tab ) => {
-      setAttributes( { [ type ]: {
-        ...attributes[ type ],
-        [ tab ]: {
-          ...attributes[ type ][ tab ],
-          value: newWidth,
-        },
-      } } );
-    },
-    [],
-  );
+  console.log( attributes.maxWidth );
 
   return (
     <InspectorControls>
-      <DevicesTabs
-      >
-        { ( { name: tab } ) => (
-          <>
-            <PanelBody initialOpen title="Dimensions Settings">
-              <ToggleControl
-                label={ __( 'Full width', 'kili-builder' ) }
-                checked={ fullWidth[ tab ]?.value }
-                onChange={ ( checked ) => handleAttributesWithDeviceChange( 'fullWidth', tab, checked ) }
-              />
-              <RangeControl
-                disabled={ fullWidth[ tab ]?.value }
-                label={ __( 'Max Width (pixels)', 'kili-builder' ) }
-                value={ parseFloat( maxWidth[ tab ]?.value ) || '' }
-                onChange={ ( newMaxWidth ) => handleWidthChange( Number( newMaxWidth ), 'maxWidth', tab ) }
-                min={ 1 }
-                max={ 2000 }
-                step={ 1 }
-              />
-              <RangeControl
-                label={ __( 'Minimum Height (pixels)', 'kili-builder' ) }
-                value={ parseFloat( minHeight[ tab ]?.value ) || '' }
-                onChange={ ( newMinHeight ) => handleWidthChange( Number( newMinHeight ), 'minHeight', tab ) }
-                min={ 1 }
-                max={ 2000 }
-                step={ 1 }
-              />
-            </PanelBody>
-            <PanelBody initialOpen title="Spacing Settings">
-              <DimensionsControl
-                { ...props }
-                device={ tab }
-                type={ 'padding' }
-                label={ __( 'Padding', 'kili-builder' ) }
-                help={ __( 'Space inside of the container.', 'kili-builder' ) }
-              />
-              <DimensionsControl
-                { ...props }
-                device={ tab }
-                type={ 'margin' }
-                label={ __( 'Margin', 'kili-builder' ) }
-                help={ __( 'Space around the container.', 'kili-builder' ) }
-              />
-            </PanelBody>
-            <BackgroundControl { ...props } device={ tab } />
-          </>
+      <DeviceTabProvider>
+        { ( tab ) => (
+          <PanelBody initialOpen title="Dimensions Settings">
+            <AdvancedRangeControl
+              disabled={ fullWidth[ tab ]?.value }
+              label={ __( 'Max Width (pixels)', 'kili-builder' ) }
+              attribute={ maxWidth }
+              onChange={ handleAttributesWithDeviceChange }
+              dimension="px"
+              min={ 1 }
+              max={ 2000 }
+              step={ 1 }
+            />
+          </PanelBody>
         ) }
-      </DevicesTabs>
+
+      </DeviceTabProvider>
+
     </InspectorControls>
   );
 }

--- a/src/blocks/container/inspector.js
+++ b/src/blocks/container/inspector.js
@@ -35,13 +35,13 @@ export default function Inspector( props ) {
             <PanelBody initialOpen title="Dimensions Settings">
               <ToggleControl
                 label={ __( 'Full width', 'kili-builder' ) }
-                checked={ fullWidth[ tab ].value }
+                checked={ fullWidth[ tab ]?.value }
                 onChange={ ( checked ) => handleAttributesWithDeviceChange( 'fullWidth', tab, checked ) }
               />
               <RangeControl
-                disabled={ fullWidth[ tab ].value }
+                disabled={ fullWidth[ tab ]?.value }
                 label={ __( 'Max Width (pixels)', 'kili-builder' ) }
-                value={ parseFloat( maxWidth[ tab ].value ) || '' }
+                value={ parseFloat( maxWidth[ tab ]?.value ) || '' }
                 onChange={ ( newMaxWidth ) => handleWidthChange( Number( newMaxWidth ), 'maxWidth', tab ) }
                 min={ 1 }
                 max={ 2000 }
@@ -49,7 +49,7 @@ export default function Inspector( props ) {
               />
               <RangeControl
                 label={ __( 'Minimum Height (pixels)', 'kili-builder' ) }
-                value={ parseFloat( minHeight[ tab ].value ) || '' }
+                value={ parseFloat( minHeight[ tab ]?.value ) || '' }
                 onChange={ ( newMinHeight ) => handleWidthChange( Number( newMinHeight ), 'minHeight', tab ) }
                 min={ 1 }
                 max={ 2000 }

--- a/src/blocks/container/style.js
+++ b/src/blocks/container/style.js
@@ -11,7 +11,7 @@ const styles = ( { attributes } ) => {
   const getValue = initGetValue( attributes );
   const prependUniqueClass = withUniqueClass( uniqueClassName );
 
-  const containerAttributes = pick( attributes, [ ...marginKeys, ...paddingKeys ] );
+  const containerAttributes = pick( attributes, [ ...marginKeys, ...paddingKeys, 'minHeight' ] );
   const containerStyles = genericStylesCreator( containerAttributes, uniqueClassName );
 
   const containerOverlayAttributes = pick( attributes, [ ...backgroundKeys, 'opacity' ] );

--- a/src/blocks/container/style.js
+++ b/src/blocks/container/style.js
@@ -1,41 +1,33 @@
 import deepmerge from 'deepmerge';
 import { genericStylesCreator } from '../utils/styles/genericStylesCreator';
-import { stylesByDeviceAccumulator, setStyleByDevice, cssPropertyValueCreator, withUniqueClass } from '../utils/styles';
+import { stylesByDeviceAccumulator, setStyleByDevice, cssPropertyValueCreator, withUniqueClass, initGetValue } from '../utils/styles';
+import { pick } from '../utils/object';
+import { marginKeys, paddingKeys, backgroundKeys } from '../../constants/attributesKeys';
+import { DEVICE_GROUP } from '../../constants';
 
 const styles = ( { attributes } ) => {
-  const {
-    fullWidth,
-    maxWidth,
-    opacity,
-    backgroundImage,
-    backgroundSize,
-    backgroundPosition,
-    backgroundColor,
-    uniqueClassName,
-    ...genericAttributes
-  } = attributes;
-  const genericStyles = genericStylesCreator( genericAttributes, uniqueClassName );
-  const genericStylesOverlay = genericStylesCreator( {
-    opacity,
-    backgroundImage,
-    backgroundSize,
-    backgroundPosition,
-    backgroundColor,
-    uniqueClassName },
-  uniqueClassName );
-  console.log( genericStylesOverlay );
+  const { uniqueClassName } = attributes;
+
+  const getValue = initGetValue( attributes );
+  const prependUniqueClass = withUniqueClass( uniqueClassName );
+
+  const containerAttributes = pick( attributes, [ ...marginKeys, ...paddingKeys ] );
+  const containerStyles = genericStylesCreator( containerAttributes, uniqueClassName );
+
+  const containerOverlayAttributes = pick( attributes, [ ...backgroundKeys, 'opacity' ] );
+  const containerOverlayStyles = genericStylesCreator( containerOverlayAttributes, prependUniqueClass( 'kili-container__overlay' ) );
 
   const stylesByDevice = stylesByDeviceAccumulator();
 
-  for ( const device of Object.keys( maxWidth ) ) {
-    const value = fullWidth[ device ].value ? 'none' : `${ maxWidth[ device ].value }`;
+  for ( const device of DEVICE_GROUP ) {
+    const value = getValue( 'fullWidth', device ) ? 'none' : `${ getValue( 'maxWidth', device ) }`;
     if ( value ) {
       const cssValue = cssPropertyValueCreator( 'max-width', value );
       setStyleByDevice( stylesByDevice, device, uniqueClassName, cssValue );
     }
   }
 
-  const stylesMerged = deepmerge.all( [ genericStyles, stylesByDevice ] );
+  const stylesMerged = deepmerge.all( [ containerStyles, stylesByDevice, containerOverlayStyles ] );
 
   return stylesMerged;
 };

--- a/src/blocks/container/style.js
+++ b/src/blocks/container/style.js
@@ -20,10 +20,15 @@ const styles = ( { attributes } ) => {
   const stylesByDevice = stylesByDeviceAccumulator();
 
   for ( const device of DEVICE_GROUP ) {
-    const value = getValue( 'fullWidth', device ) ? 'none' : `${ getValue( 'maxWidth', device ) }`;
-    if ( value ) {
-      const cssValue = cssPropertyValueCreator( 'max-width', value );
+    const newMaxWidth = getValue( 'fullWidth', device ) ? 'none' : `${ getValue( 'maxWidth', device ) }`;
+    if ( newMaxWidth ) {
+      const cssValue = cssPropertyValueCreator( 'max-width', newMaxWidth );
       setStyleByDevice( stylesByDevice, device, uniqueClassName, cssValue );
+    }
+    const backgroundImage = getValue( 'backgroundImage', device );
+    if ( backgroundImage?.url ) {
+      const cssValue = cssPropertyValueCreator( 'background-image', `url(${ backgroundImage.url })` );
+      setStyleByDevice( stylesByDevice, device, prependUniqueClass( 'kili-container__overlay' ), cssValue );
     }
   }
 

--- a/src/blocks/utils/defaultAttrBuiler.js
+++ b/src/blocks/utils/defaultAttrBuiler.js
@@ -1,21 +1,21 @@
-import { DEVICE_GROUP } from '../../constants/devicesSizes';
+import { DEVICE_GROUP, DESKTOP } from '../../constants/devicesSizes';
 import { devicesAttributes } from '../utils';
 
 // VALUE CAN BE EITHER A VALUE FOR ALL THE DEVICES || AN OBJ WITH STRUCTURE
 // { mobile: value, tablet... }
 export const defaultAttrBuiler = ( attrName, value ) => {
-  const deviceAttrs = {};
+  const defaultAttr = {
+    ...( attrName && { attrName } ),
+  };
+  const isGeneralAttr = typeof value !== 'object';
+  defaultAttr[ DESKTOP ] = {
+    ...devicesAttributes[ DESKTOP ],
+    value,
+    ...( attrName && { attrName } ),
+  };
 
-  DEVICE_GROUP.forEach( ( device ) => {
-    const isGeneralAttr = typeof value !== 'object';
-    deviceAttrs[ device ] = {
-      ...devicesAttributes[ device ],
-      value,
-      ...( attrName && { attrName } ),
-    };
-  } );
   return ( {
     type: 'object',
-    default: deviceAttrs,
+    default: defaultAttr,
   } );
 };

--- a/src/blocks/utils/object.js
+++ b/src/blocks/utils/object.js
@@ -1,0 +1,12 @@
+export function pick( object, keys ) {
+  return keys.reduce( ( obj, key ) => {
+    if ( object && object.hasOwnProperty( key ) ) {
+      obj[ key ] = object[ key ];
+    }
+    return obj;
+  }, {} );
+}
+
+export function isEmpty( obj ) {
+  return Object.keys( obj ).length === 0;
+}

--- a/src/blocks/utils/styles/genericStylesCreator.js
+++ b/src/blocks/utils/styles/genericStylesCreator.js
@@ -23,7 +23,7 @@ export const genericStylesCreator = ( attrObj, selector = '' ) => {
         let attributeClassSelector = `.${ selector }`;
         const attribute = attributes[ attrKey ];
         // Check if device is not undefined and is not at attribute with pseudo class and value already on stylesByDevice
-        if ( attribute[ device ].value && ! attributesWithNoPseudoClass.has( `${ device }${ attribute[ device ].attrName }` ) ) {
+        if ( attribute[ device ]?.value && ! attributesWithNoPseudoClass.has( `${ device }${ attribute.attrName || attribute[ device ].attrName }` ) ) {
           let attributeValue = attribute[ device ].value;
           // Check if device value is a pseudo class object
           if ( typeof attributeValue === 'object' ) {
@@ -39,9 +39,9 @@ export const genericStylesCreator = ( attrObj, selector = '' ) => {
             }
           } else {
             // Add current attribute to Set of attributesWithNoPseudoClass so it doesn't add duplicate styles.
-            attributesWithNoPseudoClass.add( `${ device }${ attribute[ device ].attrName }` );
+            attributesWithNoPseudoClass.add( `${ device }${ attribute.attrName || attribute[ device ].attrName }` );
           }
-          const cssPropertyValue = `${ attribute[ device ].attrName }:${ attributeValue };`;
+          const cssPropertyValue = `${ attribute.attrName || attribute[ device ].attrName }:${ attributeValue };`;
           // If the current selector exists, we append the current value with new one. Otherwise, initialize array.
           stylesByDevice[ device ][ attributeClassSelector ] = stylesByDevice[ device ][ attributeClassSelector ]
             ? [ ...stylesByDevice[ device ][ attributeClassSelector ], cssPropertyValue ]

--- a/src/blocks/utils/styles/index.js
+++ b/src/blocks/utils/styles/index.js
@@ -27,6 +27,9 @@ export const stylesByDeviceAccumulator = () => ( {
  */
 export const setStyleByDevice = ( stylesByDevice, device, className, value ) => {
   const selector = `.${ className }`;
+  if ( ! stylesByDevice[ device ] ) {
+    return;
+  }
   stylesByDevice[ device ][ selector ] = stylesByDevice[ device ][ selector ]
     ? [ ...stylesByDevice[ device ][ selector ], value ]
     : [ value ];
@@ -38,5 +41,9 @@ export const setStyleByDevice = ( stylesByDevice, device, className, value ) => 
  *  return the selector passed with unique block class prepended.
  */
 export const withUniqueClass = ( uniqueClass ) => {
-  return ( selector ) => `.${ uniqueClass }${ selector }`;
+  return ( selector ) => `${ uniqueClass } .${ selector }`;
+};
+
+export const initGetValue = ( attributes ) => ( attributeName, device ) => {
+  return attributes[ attributeName ][ device ]?.value;
 };

--- a/src/components/AdvancedColorPalette/index.js
+++ b/src/components/AdvancedColorPalette/index.js
@@ -1,10 +1,10 @@
-import { ToggleControl } from '@wordpress/components';
+import { ToggleControl, ColorPalette, BaseControl } from '@wordpress/components';
 import { useDeviceTab } from '../../hooks/useDeviceTab';
 import { useClientID } from '../../hooks/useClientID';
 import useAttributeSetter from '../../hooks/useAttributeSetter';
 import { useSelect } from '@wordpress/data';
 
-export default function AdvancedToggleControl( { attributeName, dimension = '', ...props } ) {
+export default function AdvancedColorPalette( { attributeName, dimension = '', label, ...props } ) {
   const { name: tab } = useDeviceTab();
   const clientID = useClientID();
   const { handleAttributesWithDeviceChange } = useAttributeSetter( clientID );
@@ -13,10 +13,11 @@ export default function AdvancedToggleControl( { attributeName, dimension = '', 
   );
 
   return (
-    <ToggleControl
-      checked={ !! currentBlockAttributes[ attributeName ][ tab ]?.value }
-      onChange={ ( value ) => handleAttributesWithDeviceChange( attributeName, tab, value, dimension ) }
-      { ...props }
-    />
+    <BaseControl label={ label } >
+      <ColorPalette
+        value={ currentBlockAttributes[ attributeName ][ tab ]?.value }
+        onChange={ ( value ) => handleAttributesWithDeviceChange( attributeName, tab, value, dimension ) }
+        { ...props }
+      /></BaseControl>
   );
 }

--- a/src/components/AdvancedColorPalette/index.js
+++ b/src/components/AdvancedColorPalette/index.js
@@ -1,23 +1,18 @@
-import { ToggleControl, ColorPalette, BaseControl } from '@wordpress/components';
-import { useDeviceTab } from '../../hooks/useDeviceTab';
-import { useClientID } from '../../hooks/useClientID';
-import useAttributeSetter from '../../hooks/useAttributeSetter';
-import { useSelect } from '@wordpress/data';
+import { ColorPalette, BaseControl } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import withAdvancedControls from '../../hoc/withAdvancedControls';
 
-export default function AdvancedColorPalette( { attributeName, dimension = '', label, ...props } ) {
-  const { name: tab } = useDeviceTab();
-  const clientID = useClientID();
-  const { handleAttributesWithDeviceChange } = useAttributeSetter( clientID );
-  const currentBlockAttributes = useSelect(
-    ( select ) => select( 'core/block-editor' ).getBlockAttributes( clientID )
-  );
-
+function AdvancedColorPalette( { label, value, ...props } ) {
   return (
-    <BaseControl label={ label } >
+    <BaseControl label={ label } id="colorPalette" >
       <ColorPalette
-        value={ currentBlockAttributes[ attributeName ][ tab ]?.value }
-        onChange={ ( value ) => handleAttributesWithDeviceChange( attributeName, tab, value, dimension ) }
+        value={ value }
         { ...props }
-      /></BaseControl>
+      />
+    </BaseControl>
   );
 }
+
+export default compose(
+  withAdvancedControls
+)( AdvancedColorPalette );

--- a/src/components/AdvancedRangeControl/index.js
+++ b/src/components/AdvancedRangeControl/index.js
@@ -1,0 +1,16 @@
+import { RangeControl } from '@wordpress/components';
+import { useDeviceTab } from '../../hooks/useDeviceTab';
+import { __ } from '@wordpress/i18n';
+
+export default function AdvancedRangeControl( { attribute, onChange = () => {}, dimension = '', ...props } ) {
+  const { name: tab } = useDeviceTab();
+  console.log( { [ attribute ]: attribute } );
+  const attributeName = Object.keys( { [ attribute ]: attribute } )[ 0 ];
+  return (
+    <RangeControl
+      value={ parseFloat( attribute[ tab ]?.value ) || '' }
+      onChange={ ( value ) => onChange( attributeName, tab, value, dimension ) }
+      { ...props }
+    />
+  );
+}

--- a/src/components/AdvancedRangeControl/index.js
+++ b/src/components/AdvancedRangeControl/index.js
@@ -1,15 +1,22 @@
 import { RangeControl } from '@wordpress/components';
 import { useDeviceTab } from '../../hooks/useDeviceTab';
 import { __ } from '@wordpress/i18n';
+import { useClientID } from '../../hooks/useClientID';
+import useAttributeSetter from '../../hooks/useAttributeSetter';
+import { useSelect } from '@wordpress/data';
 
-export default function AdvancedRangeControl( { attribute, onChange = () => {}, dimension = '', ...props } ) {
+export default function AdvancedRangeControl( { attributeName, dimension = '', ...props } ) {
   const { name: tab } = useDeviceTab();
-  console.log( { [ attribute ]: attribute } );
-  const attributeName = Object.keys( { [ attribute ]: attribute } )[ 0 ];
+  const clientID = useClientID();
+  const { handleAttributesWithDeviceChange } = useAttributeSetter( clientID );
+  const currentBlockAttributes = useSelect(
+    ( select ) => select( 'core/block-editor' ).getBlockAttributes( clientID )
+  );
+
   return (
     <RangeControl
-      value={ parseFloat( attribute[ tab ]?.value ) || '' }
-      onChange={ ( value ) => onChange( attributeName, tab, value, dimension ) }
+      value={ parseFloat( currentBlockAttributes[ attributeName ][ tab ]?.value ) || '' }
+      onChange={ ( value ) => handleAttributesWithDeviceChange( attributeName, tab, value, dimension ) }
       { ...props }
     />
   );

--- a/src/components/AdvancedRangeControl/index.js
+++ b/src/components/AdvancedRangeControl/index.js
@@ -1,23 +1,16 @@
 import { RangeControl } from '@wordpress/components';
-import { useDeviceTab } from '../../hooks/useDeviceTab';
-import { __ } from '@wordpress/i18n';
-import { useClientID } from '../../hooks/useClientID';
-import useAttributeSetter from '../../hooks/useAttributeSetter';
-import { useSelect } from '@wordpress/data';
+import withAdvancedControls from '../../hoc/withAdvancedControls';
+import { compose } from '@wordpress/compose';
 
-export default function AdvancedRangeControl( { attributeName, dimension = '', ...props } ) {
-  const { name: tab } = useDeviceTab();
-  const clientID = useClientID();
-  const { handleAttributesWithDeviceChange } = useAttributeSetter( clientID );
-  const currentBlockAttributes = useSelect(
-    ( select ) => select( 'core/block-editor' ).getBlockAttributes( clientID )
-  );
-
+function AdvancedRangeControl( { value, ...props } ) {
   return (
     <RangeControl
-      value={ parseFloat( currentBlockAttributes[ attributeName ][ tab ]?.value ) || '' }
-      onChange={ ( value ) => handleAttributesWithDeviceChange( attributeName, tab, value, dimension ) }
+      value={ parseFloat( value ) || '' }
       { ...props }
     />
   );
 }
+
+export default compose(
+  withAdvancedControls
+)( AdvancedRangeControl );

--- a/src/components/AdvancedToggleControl/AdvancedToggleControl.js
+++ b/src/components/AdvancedToggleControl/AdvancedToggleControl.js
@@ -1,22 +1,16 @@
 import { ToggleControl } from '@wordpress/components';
-import { useDeviceTab } from '../../hooks/useDeviceTab';
-import { useClientID } from '../../hooks/useClientID';
-import useAttributeSetter from '../../hooks/useAttributeSetter';
-import { useSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import withAdvancedControls from '../../hoc/withAdvancedControls';
 
-export default function AdvancedToggleControl( { attributeName, dimension = '', ...props } ) {
-  const { name: tab } = useDeviceTab();
-  const clientID = useClientID();
-  const { handleAttributesWithDeviceChange } = useAttributeSetter( clientID );
-  const currentBlockAttributes = useSelect(
-    ( select ) => select( 'core/block-editor' ).getBlockAttributes( clientID )
-  );
-
+function AdvancedToggleControl( { value, ...props } ) {
   return (
     <ToggleControl
-      checked={ !! currentBlockAttributes[ attributeName ][ tab ]?.value }
-      onChange={ ( value ) => handleAttributesWithDeviceChange( attributeName, tab, value, dimension ) }
+      checked={ !! value }
       { ...props }
     />
   );
 }
+
+export default compose(
+  withAdvancedControls
+)( AdvancedToggleControl );

--- a/src/components/AdvancedToggleControl/AdvancedToggleControl.js
+++ b/src/components/AdvancedToggleControl/AdvancedToggleControl.js
@@ -1,0 +1,22 @@
+import { ToggleControl } from '@wordpress/components';
+import { useDeviceTab } from '../../hooks/useDeviceTab';
+import { useClientID } from '../../hooks/useClientID';
+import useAttributeSetter from '../../hooks/useAttributeSetter';
+import { useSelect } from '@wordpress/data';
+
+export default function AdvancedToggleControl( { attributeName, dimension = '', ...props } ) {
+  const { name: tab } = useDeviceTab();
+  const clientID = useClientID();
+  const { handleAttributesWithDeviceChange } = useAttributeSetter( clientID );
+  const currentBlockAttributes = useSelect(
+    ( select ) => select( 'core/block-editor' ).getBlockAttributes( clientID )
+  );
+
+  return (
+    <ToggleControl
+      checked={ currentBlockAttributes[ attributeName ][ tab ]?.value }
+      onChange={ ( value ) => handleAttributesWithDeviceChange( attributeName, tab, value, dimension ) }
+      { ...props }
+    />
+  );
+}

--- a/src/components/Background/attributes.js
+++ b/src/components/Background/attributes.js
@@ -1,4 +1,4 @@
-import { defaultAttrBuiler } from "../../blocks/utils";
+import { defaultAttrBuiler } from '../../blocks/utils';
 
 /**
  * Set the attributes for the Background Panel
@@ -6,11 +6,11 @@ import { defaultAttrBuiler } from "../../blocks/utils";
  * @type {Object}
  */
 const BackgroundAttributes = {
-  opacity: defaultAttrBuiler('opacity', 1),
-  backgroundImage: defaultAttrBuiler('background-image'),
-  backgroundSize: defaultAttrBuiler('background-size', 'cover'),
-  backgroundPosition: defaultAttrBuiler('background-position', 'center'),
-  backgroundColor: defaultAttrBuiler('background-color'),
+  opacity: defaultAttrBuiler( 'opacity', 1 ),
+  backgroundImage: defaultAttrBuiler( 'background-image' ),
+  backgroundSize: defaultAttrBuiler( 'background-size', 'cover' ),
+  backgroundPosition: defaultAttrBuiler( 'background-position', 'center' ),
+  backgroundColor: defaultAttrBuiler( 'background-color' ),
 };
 
 export default BackgroundAttributes;

--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -3,6 +3,9 @@ import { attrOptionsBuiler } from '../../blocks/utils';
 import { MediaUploadCheck, MediaUpload, PanelColorSettings } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { COLORS } from '../../constants';
+import AdvancedRangeControl from '../AdvancedRangeControl';
+import AdvancedColorPalette from '../AdvancedColorPalette';
+import ImageControl from '../ImageControl';
 
 const { useCallback } = wp.element;
 
@@ -13,15 +16,7 @@ const backgroundImageSizeOptions = attrOptionsBuiler( [
 ] );
 
 export default function BackgroundControl( { attributes, setAttributes, device } ) {
-  const { id, url, alt, fullWidth, backgroundColor, backgroundImage, backgroundSize, opacity } = attributes;
-
-  const onRemoveImage = () => {
-    setAttributes( {
-      id: null,
-      url: null,
-      alt: null,
-    } );
-  };
+  const { id, url, alt, backgroundImage, backgroundSize } = attributes;
 
   const handleBackgroundAttrChange = useCallback(
     ( value, attrName ) => {
@@ -41,45 +36,29 @@ export default function BackgroundControl( { attributes, setAttributes, device }
   return (
     <>
       <PanelBody title={ __( 'Background Settings', 'kili-builder' ) }>
-        <RangeControl
+        <AdvancedRangeControl
           label={ __( 'Opacity', 'kili-builder' ) }
-          value={ Number( opacity[ device ]?.value ) }
-          onChange={ ( newOpacity ) => handleBackgroundAttrChange( Number( newOpacity ), 'opacity' ) }
+          attributeName="opacity"
           min={ 0 }
           max={ 1 }
           step={ 0.01 }
         />
-        <BaseControl label="Color">
-          <ColorPalette
-            colors={ COLORS }
-            value={ backgroundColor[ device ]?.value }
-            onChange={ ( value ) => handleBackgroundAttrChange( value, 'backgroundColor' ) }
-          />
-        </BaseControl>
+        <AdvancedColorPalette
+          attributeName="backgroundColor"
+          label="Color"
+          colors={ COLORS }
+        />
         <MediaUploadCheck>
-          <MediaUpload
-            value={ id }
+          <ImageControl
+            attributeName="backgroundImage"
+            label={ __( 'Background Image', 'kili-builder' ) }
+            id={ id }
             onSelect={ ( img ) => handleBackgroundAttrChange( `url(${ img.url })`, 'backgroundImage' ) }
             allowedTypes={ [ 'image' ] }
-            render={ ( { open } ) => {
-              return (
-                <BaseControl label="Add Image">
-                  <IconButton
-                    className="button--add_edit"
-                    label={ __(
-                      `${ url ? 'Edit Image' : 'Add Image' }`,
-                      'kili-builder'
-                    ) }
-                    onClick={ open }
-                    icon="format-image"
-                  />
-                </BaseControl>
-              );
-            } }
           />
         </MediaUploadCheck>
 
-        { backgroundImage[ device ]?.value && (
+        { backgroundImage[ device ]?.value?.url && (
           <>
             <SelectControl
               className={ 'components-font-size-picker__select' }

--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -4,8 +4,6 @@ import { MediaUploadCheck, MediaUpload, PanelColorSettings } from '@wordpress/bl
 import { __ } from '@wordpress/i18n';
 import { COLORS } from '../../constants';
 
-
-
 const { useCallback } = wp.element;
 
 const backgroundImageSizeOptions = attrOptionsBuiler( [
@@ -15,7 +13,7 @@ const backgroundImageSizeOptions = attrOptionsBuiler( [
 ] );
 
 export default function BackgroundControl( { attributes, setAttributes, device } ) {
-  const { id, url, alt, fullWidth, backgroundColor,backgroundImage, backgroundSize, opacity } = attributes;
+  const { id, url, alt, fullWidth, backgroundColor, backgroundImage, backgroundSize, opacity } = attributes;
 
   const onRemoveImage = () => {
     setAttributes( {
@@ -26,26 +24,26 @@ export default function BackgroundControl( { attributes, setAttributes, device }
   };
 
   const handleBackgroundAttrChange = useCallback(
-    (value, attrName) => {
-      setAttributes({
-        [attrName]: {
-          ...attributes[attrName],
-          [device]: {
-            ...attributes[attrName][device],
-            value
-          }
-        }
-      })
+    ( value, attrName ) => {
+      setAttributes( {
+        [ attrName ]: {
+          ...attributes[ attrName ],
+          [ device ]: {
+            ...attributes[ attrName ][ device ],
+            value,
+          },
+        },
+      } );
     },
-    [attributes, device],
-  )
+    [ attributes, device ],
+  );
 
   return (
     <>
       <PanelBody title={ __( 'Background Settings', 'kili-builder' ) }>
         <RangeControl
           label={ __( 'Opacity', 'kili-builder' ) }
-          value={ Number(opacity[ device ].value) }
+          value={ Number( opacity[ device ]?.value ) }
           onChange={ ( newOpacity ) => handleBackgroundAttrChange( Number( newOpacity ), 'opacity' ) }
           min={ 0 }
           max={ 1 }
@@ -53,15 +51,15 @@ export default function BackgroundControl( { attributes, setAttributes, device }
         />
         <BaseControl label="Color">
           <ColorPalette
-            colors={COLORS}
-            value={backgroundColor[device].value}
-            onChange={(value) => handleBackgroundAttrChange(value, 'backgroundColor')}
+            colors={ COLORS }
+            value={ backgroundColor[ device ]?.value }
+            onChange={ ( value ) => handleBackgroundAttrChange( value, 'backgroundColor' ) }
           />
         </BaseControl>
         <MediaUploadCheck>
           <MediaUpload
             value={ id }
-            onSelect={ ( img ) => handleBackgroundAttrChange( `url(${img.url})`, 'backgroundImage' ) }
+            onSelect={ ( img ) => handleBackgroundAttrChange( `url(${ img.url })`, 'backgroundImage' ) }
             allowedTypes={ [ 'image' ] }
             render={ ( { open } ) => {
               return (
@@ -78,27 +76,27 @@ export default function BackgroundControl( { attributes, setAttributes, device }
                 </BaseControl>
               );
             } }
-            />
-          </MediaUploadCheck>
+          />
+        </MediaUploadCheck>
 
-        { backgroundImage[device].value && (
+        { backgroundImage[ device ]?.value && (
           <>
             <SelectControl
               className={ 'components-font-size-picker__select' }
               label={ `Background Image Size` }
-              value={backgroundSize[device].value}
+              value={ backgroundSize[ device ]?.value }
               options={ backgroundImageSizeOptions }
-              onChange={(value) => handleBackgroundAttrChange(value, 'backgroundSize')}
+              onChange={ ( value ) => handleBackgroundAttrChange( value, 'backgroundSize' ) }
             />
             <SelectControl
               className={ 'components-font-size-picker__select' }
               label={ `Background Position` }
-              value={backgroundSize[device].value}
+              value={ backgroundSize[ device ]?.value }
               options={ backgroundImageSizeOptions }
-              onChange={(value) => handleBackgroundAttrChange(value, 'backgroundSize')}
+              onChange={ ( value ) => handleBackgroundAttrChange( value, 'backgroundSize' ) }
             />
           </>
-        )}
+        ) }
 
       </PanelBody>
     </>

--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -53,7 +53,6 @@ export default function BackgroundControl( { attributes, setAttributes, device }
             attributeName="backgroundImage"
             label={ __( 'Background Image', 'kili-builder' ) }
             id={ id }
-            onSelect={ ( img ) => handleBackgroundAttrChange( `url(${ img.url })`, 'backgroundImage' ) }
             allowedTypes={ [ 'image' ] }
           />
         </MediaUploadCheck>

--- a/src/components/BlockStyles/BlockStyles.js
+++ b/src/components/BlockStyles/BlockStyles.js
@@ -10,7 +10,7 @@ function BlockStyles( { styles } ) {
         deviceStyles += `${ mediaQuery }${ selector }{ ${ value.join( '' ) } }`;
       }
 
-      if ( device !== DESKTOP ) {
+      if ( device !== DESKTOP && deviceStyles ) {
         deviceStyles = `@media screen and (max-width:${ BREAKPOINTS_VALUES[ device ] }){${ deviceStyles }}`;
       }
 

--- a/src/components/DimensionsControl/index.js
+++ b/src/components/DimensionsControl/index.js
@@ -52,28 +52,28 @@ export default function DimensionsControl( { device,
               className="components-kili-dimensions-control__number"
               type="number"
               onChange={ ( e ) => onChangeDirection( e, 'Top' ) }
-              value={ parseFloat( attributes[ `${ type }Top` ][ device ].value ) ? parseFloat( attributes[ `${ type }Top` ][ device ].value ) : 0 }
+              value={ parseFloat( attributes[ `${ type }Top` ][ device ]?.value ) || 0 }
               min={ type === 'padding' ? 0 : undefined }
             />
             <input
               className="components-kili-dimensions-control__number"
               type="number"
               onChange={ ( e ) => onChangeDirection( e, 'Right' ) }
-              value={ parseFloat( attributes[ `${ type }Right` ][ device ].value ) ? parseFloat( attributes[ `${ type }Right` ][ device ].value ) : 0 }
+              value={ parseFloat( attributes[ `${ type }Right` ][ device ]?.value ) ? parseFloat( attributes[ `${ type }Right` ][ device ].value ) : 0 }
               min={ type === 'padding' ? 0 : undefined }
             />
             <input
               className="components-kili-dimensions-control__number"
               type="number"
               onChange={ ( e ) => onChangeDirection( e, 'Bottom' ) }
-              value={ parseFloat( attributes[ `${ type }Bottom` ][ device ].value ) ? parseFloat( attributes[ `${ type }Bottom` ][ device ].value ) : 0 }
+              value={ parseFloat( attributes[ `${ type }Bottom` ][ device ]?.value ) ? parseFloat( attributes[ `${ type }Bottom` ][ device ].value ) : 0 }
               min={ type === 'padding' ? 0 : undefined }
             />
             <input
               className="components-kili-dimensions-control__number"
               type="number"
               onChange={ ( e ) => onChangeDirection( e, 'Left' ) }
-              value={ parseFloat( attributes[ `${ type }Left` ][ device ].value ) ? parseFloat( attributes[ `${ type }Left` ][ device ].value ) : 0 }
+              value={ parseFloat( attributes[ `${ type }Left` ][ device ]?.value ) ? parseFloat( attributes[ `${ type }Left` ][ device ].value ) : 0 }
               min={ type === 'padding' ? 0 : undefined }
             />
             <Tooltip text={ __( 'Reset', 'kili-builder' ) } >

--- a/src/components/ImageControl/editor.scss
+++ b/src/components/ImageControl/editor.scss
@@ -1,0 +1,63 @@
+.ugb-image-control {
+	.ugb-placeholder {
+		height: 150px;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		background: #f1f1f1;
+		margin-bottom: 12px;
+		margin-top: 0.6rem;
+		svg {
+			height: 50px;
+			fill: #ddd;
+		}
+	}
+	.ugb-placeholder,
+	.ugb-image-preview {
+		border-radius: 4px;
+		cursor: pointer;
+		transition: all 0.3s ease-in-out;
+		&:hover {
+			background: #fafafa;
+		}
+		&:focus {
+			background: #fafafa;
+			box-shadow: 0 0 0 2px rgba(30, 140, 190, 0.8);
+		}
+	}
+	.ugb-image-preview-wrapper {
+		position: relative;
+		z-index: 1; // Prevent this from going on top of the 3-tabs.
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		background: #f1f1f1;
+		margin-top: 0.6rem;
+		border-radius: 4px;
+		svg {
+			stroke: rgba(0, 0, 0, 0.3);
+			stroke-width: 1px;
+			fill: #fff;
+		}
+	}
+	.ugb-image-preview {
+		min-width: 100px;
+		flex: 1 1 100px;
+		margin: 0;
+		position: relative;
+		z-index: 2;
+		object-fit: contain;
+		width: auto;
+		height: auto;
+	}
+	.ugb-image-preview-remove {
+		background: none !important;
+		color: #ddd;
+		border: none;
+		position: absolute;
+		top: 10px;
+		right: 4px;
+		cursor: pointer;
+		z-index: 3;
+	}
+}

--- a/src/components/ImageControl/editor.scss
+++ b/src/components/ImageControl/editor.scss
@@ -1,5 +1,5 @@
-.ugb-image-control {
-	.ugb-placeholder {
+.kili-image-control {
+	.kili-placeholder {
 		height: 150px;
 		display: flex;
 		justify-content: center;
@@ -12,8 +12,8 @@
 			fill: #ddd;
 		}
 	}
-	.ugb-placeholder,
-	.ugb-image-preview {
+	.kili-placeholder,
+	.kili-image-preview__image {
 		border-radius: 4px;
 		cursor: pointer;
 		transition: all 0.3s ease-in-out;
@@ -25,7 +25,7 @@
 			box-shadow: 0 0 0 2px rgba(30, 140, 190, 0.8);
 		}
 	}
-	.ugb-image-preview-wrapper {
+	.kili-image-preview {
 		position: relative;
 		z-index: 1; // Prevent this from going on top of the 3-tabs.
 		display: flex;
@@ -40,7 +40,7 @@
 			fill: #fff;
 		}
 	}
-	.ugb-image-preview {
+	.kili-image-preview__image {
 		min-width: 100px;
 		flex: 1 1 100px;
 		margin: 0;
@@ -50,7 +50,7 @@
 		width: auto;
 		height: auto;
 	}
-	.ugb-image-preview-remove {
+	.kili-image-preview__remove {
 		background: none !important;
 		color: #ddd;
 		border: none;

--- a/src/components/ImageControl/editor.scss
+++ b/src/components/ImageControl/editor.scss
@@ -1,63 +1,63 @@
 .kili-image-control {
-	.kili-placeholder {
-		height: 150px;
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		background: #f1f1f1;
-		margin-bottom: 12px;
-		margin-top: 0.6rem;
-		svg {
-			height: 50px;
-			fill: #ddd;
-		}
-	}
-	.kili-placeholder,
-	.kili-image-preview__image {
-		border-radius: 4px;
-		cursor: pointer;
-		transition: all 0.3s ease-in-out;
-		&:hover {
-			background: #fafafa;
-		}
-		&:focus {
-			background: #fafafa;
-			box-shadow: 0 0 0 2px rgba(30, 140, 190, 0.8);
-		}
-	}
-	.kili-image-preview {
-		position: relative;
-		z-index: 1; // Prevent this from going on top of the 3-tabs.
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		background: #f1f1f1;
-		margin-top: 0.6rem;
-		border-radius: 4px;
-		svg {
-			stroke: rgba(0, 0, 0, 0.3);
-			stroke-width: 1px;
-			fill: #fff;
-		}
-	}
-	.kili-image-preview__image {
-		min-width: 100px;
-		flex: 1 1 100px;
-		margin: 0;
-		position: relative;
-		z-index: 2;
-		object-fit: contain;
-		width: auto;
-		height: auto;
-	}
-	.kili-image-preview__remove {
-		background: none !important;
-		color: #ddd;
-		border: none;
-		position: absolute;
-		top: 10px;
-		right: 4px;
-		cursor: pointer;
-		z-index: 3;
-	}
+  .kili-placeholder {
+    height: 150px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: #f1f1f1;
+    margin-bottom: 12px;
+    margin-top: 0.6rem;
+    svg {
+      height: 50px;
+      fill: #ddd;
+    }
+  }
+  .kili-placeholder,
+  .kili-image-preview__image {
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.3s ease-in-out;
+    &:hover {
+      background: #fafafa;
+    }
+    &:focus {
+      background: #fafafa;
+      box-shadow: 0 0 0 2px rgba(30, 140, 190, 0.8);
+    }
+  }
+  .kili-image-preview {
+    position: relative;
+    z-index: 1; // Prevent this from going on top of the 3-tabs.
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: #f1f1f1;
+    margin-top: 0.6rem;
+    border-radius: 4px;
+    svg {
+      stroke: rgba(0, 0, 0, 0.3);
+      stroke-width: 1px;
+      fill: #fff;
+    }
+  }
+  .kili-image-preview__image {
+    min-width: 100px;
+    flex: 1 1 100px;
+    margin: 0;
+    position: relative;
+    z-index: 2;
+    object-fit: contain;
+    width: auto;
+    height: auto;
+  }
+  .kili-image-preview__remove {
+    background: none !important;
+    color: #ddd;
+    border: none;
+    position: absolute;
+    top: 10px;
+    right: 4px;
+    cursor: pointer;
+    z-index: 3;
+  }
 }

--- a/src/components/ImageControl/index.js
+++ b/src/components/ImageControl/index.js
@@ -1,0 +1,103 @@
+
+import { BaseControl, Dashicon, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { MediaUpload } from '@wordpress/block-editor';
+
+import './editor.scss';
+import { useDeviceTab } from '../../hooks/useDeviceTab';
+import { useClientID } from '../../hooks/useClientID';
+import useAttributeSetter from '../../hooks/useAttributeSetter';
+import { useSelect } from '@wordpress/data';
+import { pick } from '../../blocks/utils/object';
+
+const ImageControl = ( { attributeName, dimension, ...props } ) => {
+  const { name: tab } = useDeviceTab();
+  const clientID = useClientID();
+  const { handleAttributesWithDeviceChange } = useAttributeSetter( clientID );
+  const currentBlockAttributes = useSelect(
+    ( select ) => select( 'core/block-editor' ).getBlockAttributes( clientID )
+  );
+  const onRemove = () => {
+    if ( props.onRemove ) {
+      props.onRemove();
+    } else {
+      props.onChange( {
+        url: '',
+        id: '',
+        width: '',
+        height: '',
+      } );
+    }
+  };
+
+  const selectedImage = currentBlockAttributes[ attributeName ][ tab ]?.value;
+  console.log( selectedImage );
+
+  return (
+    <div className="ugb-image-control">
+      <BaseControl label={ props.label } help={ props.help }>
+        <MediaUpload
+          onSelect={
+            ( value ) => (
+              handleAttributesWithDeviceChange( attributeName, tab, value, dimension )
+            )
+          }
+          allowedTypes={ [ 'image' ] }
+          value={ selectedImage?.id }
+          render={ ( obj ) => {
+            return (
+              <>
+                { selectedImage?.url &&
+                <div className="ugb-image-preview-wrapper">
+                  <button
+                    className="ugb-image-preview-remove"
+                    onClick={
+                      ( ) => (
+                        handleAttributesWithDeviceChange( attributeName, tab, { url: '', id: '', alt: '' } )
+                      )
+                    }
+                  >
+                    <Dashicon icon="no" />
+                  </button>
+                  <img
+                    className="ugb-image-preview"
+                    src={ selectedImage?.url }
+                    alt="Test alt preview"
+                  />
+                </div>
+                }
+                { ! selectedImage?.url && (
+                  <div
+                    className="ugb-placeholder"
+                    onClick={ obj.open }
+                    onKeyDown={ ( event ) => {
+                      if ( event.keyCode === 13 ) {
+                        obj.open();
+                      }
+                    } }
+                    role="button"
+                    tabIndex={ 0 }
+                  >
+                    <Icon icon="format-image" />
+                  </div>
+                ) }
+              </>
+            );
+          } }
+        />
+      </BaseControl>
+    </div>
+  );
+};
+
+ImageControl.defaultProps = {
+  label: '',
+  id: '',
+  url: '',
+	onChange: ( { url, id, width, height } ) => {}, // eslint-disable-line
+  onRemove: () => {},
+  allowedTypes: [ 'image' ],
+  help: '',
+};
+
+export default ImageControl;

--- a/src/components/ImageControl/index.js
+++ b/src/components/ImageControl/index.js
@@ -61,8 +61,7 @@ ImageControl.defaultProps = {
   label: '',
   id: '',
   url: '',
-	onChange: ( { url, id, width, height } ) => {}, // eslint-disable-line
-  onRemove: () => {},
+  onChange: ( { url, id, width, height } ) => {},
   allowedTypes: [ 'image' ],
   help: '',
 };

--- a/src/components/ImageControl/index.js
+++ b/src/components/ImageControl/index.js
@@ -4,71 +4,38 @@ import { __ } from '@wordpress/i18n';
 import { MediaUpload } from '@wordpress/block-editor';
 
 import './editor.scss';
-import { useDeviceTab } from '../../hooks/useDeviceTab';
-import { useClientID } from '../../hooks/useClientID';
-import useAttributeSetter from '../../hooks/useAttributeSetter';
-import { useSelect } from '@wordpress/data';
-import { pick } from '../../blocks/utils/object';
+import { compose } from '@wordpress/compose';
+import withAdvancedControls from '../../hoc/withAdvancedControls';
 
-const ImageControl = ( { attributeName, dimension, ...props } ) => {
-  const { name: tab } = useDeviceTab();
-  const clientID = useClientID();
-  const { handleAttributesWithDeviceChange } = useAttributeSetter( clientID );
-  const currentBlockAttributes = useSelect(
-    ( select ) => select( 'core/block-editor' ).getBlockAttributes( clientID )
-  );
-  const onRemove = () => {
-    if ( props.onRemove ) {
-      props.onRemove();
-    } else {
-      props.onChange( {
-        url: '',
-        id: '',
-        width: '',
-        height: '',
-      } );
-    }
-  };
-
-  const selectedImage = currentBlockAttributes[ attributeName ][ tab ]?.value;
-  console.log( selectedImage );
-
+const ImageControl = ( { value, onChange, ...props } ) => {
   return (
-    <div className="ugb-image-control">
+    <div className="kili-image-control">
       <BaseControl label={ props.label } help={ props.help }>
         <MediaUpload
-          onSelect={
-            ( value ) => (
-              handleAttributesWithDeviceChange( attributeName, tab, value, dimension )
-            )
-          }
+          onSelect={ onChange }
           allowedTypes={ [ 'image' ] }
-          value={ selectedImage?.id }
+          value={ value?.id }
           render={ ( obj ) => {
             return (
               <>
-                { selectedImage?.url &&
-                <div className="ugb-image-preview-wrapper">
+                { value?.url &&
+                <div className="kili-image-preview">
                   <button
-                    className="ugb-image-preview-remove"
-                    onClick={
-                      ( ) => (
-                        handleAttributesWithDeviceChange( attributeName, tab, { url: '', id: '', alt: '' } )
-                      )
-                    }
+                    className="kili-image-preview__remove"
+                    onClick={ () => onChange( { url: '', id: '', alt: '' } ) }
                   >
                     <Dashicon icon="no" />
                   </button>
                   <img
-                    className="ugb-image-preview"
-                    src={ selectedImage?.url }
+                    className="kili-image-preview__image"
+                    src={ value?.url }
                     alt="Test alt preview"
                   />
                 </div>
                 }
-                { ! selectedImage?.url && (
+                { ! value?.url && (
                   <div
-                    className="ugb-placeholder"
+                    className="kili-placeholder"
                     onClick={ obj.open }
                     onKeyDown={ ( event ) => {
                       if ( event.keyCode === 13 ) {
@@ -100,4 +67,6 @@ ImageControl.defaultProps = {
   help: '',
 };
 
-export default ImageControl;
+export default compose(
+  withAdvancedControls
+)( ImageControl );

--- a/src/constants/attributesKeys.js
+++ b/src/constants/attributesKeys.js
@@ -1,0 +1,3 @@
+export const backgroundKeys = [ 'backgroundImage', 'backgroundSize', 'backgroundPosition', 'backgroundColor' ];
+export const marginKeys = [ 'marginTop', 'marginBottom', 'marginRight', 'marginLeft' ];
+export const paddingKeys = [ 'paddingTop', 'paddingBottom', 'paddingRight', 'paddingLeft' ];

--- a/src/hoc/withAdvancedControls.js
+++ b/src/hoc/withAdvancedControls.js
@@ -1,0 +1,31 @@
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useDeviceTab } from '../hooks/useDeviceTab';
+import { useClientID } from '../hooks/useClientID';
+import useAttributeSetter from '../hooks/useAttributeSetter';
+import { useSelect } from '@wordpress/data';
+/**
+ *
+ * @return {Function} Add editor and block attributes to base Gutenberg controls as props
+ *  */
+const withAdvancedControls = createHigherOrderComponent(
+  ( WrappedComponent ) => ( props ) => {
+    const { name: tab } = useDeviceTab();
+    const clientID = useClientID();
+    const { handleAttributesWithDeviceChange } = useAttributeSetter( clientID );
+    const currentBlockAttributes = useSelect(
+      ( select ) => select( 'core/block-editor' ).getBlockAttributes( clientID )
+    );
+    return (
+      <WrappedComponent
+        { ...props }
+        tab={ tab }
+        value={ currentBlockAttributes[ props.attributeName ][ tab ]?.value }
+        onChange={ ( value ) => handleAttributesWithDeviceChange( props.attributeName, tab, value, props.dimension ) }
+      />
+    );
+  },
+  'withAdvancedControls'
+);
+
+export default withAdvancedControls
+;

--- a/src/hoc/withClientID.js
+++ b/src/hoc/withClientID.js
@@ -1,0 +1,19 @@
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { ClientIDProvider } from '../hooks/useClientID';
+/**
+ *
+ * @return {Function} Component with ClientIDProvider, so the value can be accesed with useClientID.
+ *  */
+const withClientID = createHigherOrderComponent(
+  ( WrappedComponent ) => ( props ) => {
+    return (
+      <ClientIDProvider clientID={ props.clientId }>
+        <WrappedComponent { ...props } />
+      </ClientIDProvider>
+    );
+  },
+  'withClientID'
+);
+
+export default withClientID
+;

--- a/src/hooks/useClientID.js
+++ b/src/hooks/useClientID.js
@@ -4,8 +4,6 @@ const { useContext, createContext } = wp.element;
 const ClientIDContext = createContext();
 
 export function ClientIDProvider( { children, clientID } ) {
-  console.log( clientID );
-
   return (
     <ClientIDContext.Provider value={ clientID }>
       { children }

--- a/src/hooks/useClientID.js
+++ b/src/hooks/useClientID.js
@@ -1,0 +1,23 @@
+
+const { useContext, createContext } = wp.element;
+
+const ClientIDContext = createContext();
+
+export function ClientIDProvider( { children, clientID } ) {
+  console.log( clientID );
+
+  return (
+    <ClientIDContext.Provider value={ clientID }>
+      { children }
+    </ClientIDContext.Provider>
+
+  );
+}
+
+export function useClientID() {
+  const context = useContext( ClientIDContext );
+  if ( ! context ) {
+    throw new Error( `useClientID must be used within a ClientIDProvider` );
+  }
+  return context;
+}

--- a/src/hooks/useDeviceTab.js
+++ b/src/hooks/useDeviceTab.js
@@ -1,0 +1,52 @@
+
+import { Icon, TabPanel } from '@wordpress/components';
+
+const { useContext, createContext } = wp.element;
+
+const DeviceTabContext = createContext();
+
+export function DeviceTabProvider( { children } ) {
+  return (
+    <TabPanel
+      className="kt-inspect-tabs"
+      activeClass="active-tab"
+      initialTabName="desktop"
+      tabs={ [
+        {
+          name: 'desktop',
+          title: <Icon icon="desktop" />,
+          className: '',
+        },
+        {
+          name: 'tablet',
+          title: <Icon icon="tablet" />,
+          className: '',
+        },
+        {
+          name: 'mobile',
+          title: <Icon icon="smartphone" />,
+          className: '',
+        },
+      ] }
+    >
+      { ( tab ) => {
+        return (
+          <>
+            <DeviceTabContext.Provider value={ tab }>
+              { typeof children === 'function' ? children( tab ) : children }
+            </DeviceTabContext.Provider>
+          </>
+        );
+      } }
+    </TabPanel>
+
+  );
+}
+
+export function useDeviceTab() {
+  const context = useContext( DeviceTabContext );
+  if ( ! context ) {
+    throw new Error( `useDeviceTab must be used within a DeviceTabProvider` );
+  }
+  return context;
+}


### PR DESCRIPTION
- Created AdvancedControls for basic inspector controls (RangeControl, ToggleControl, ImageControl, ColorPalette). This new components were created with a Higher Order Component that access the block attributes and clientId through a ContextProvider. This way, we don't have to include the value and onChange function on every single input/control. Only the attribute name is required, and the helper HOCs and Context manage the rest.

- Made a reusable ImageControl with preview image, and remove button.

- Created a pick keys from Object utility function. This will be mostly used on block styling by picking only the attributes you will attach to a selector.